### PR TITLE
Feature/#9 comunity page develope

### DIFF
--- a/src/api/mock/community.json
+++ b/src/api/mock/community.json
@@ -1,0 +1,18 @@
+[
+    {
+      "id": 1,
+      "name": "리액트 100일 스터디",
+      "notice": "호스트가 공지글을 게시했습니다.",
+      "time": "오후 8:36",
+      "image": "/path/to/react_study.png"
+    },
+    {
+      "id": 2,
+      "name": "토익 스터디 커뮤니티",
+      "notice": "@Lundean 님이 입장했습니다.",
+      "time": "오후 5:40",
+      "image": "/path/to/toeic_study.png",
+      "badge": "50+"
+    }
+  ]
+  

--- a/src/components/CommunityItem.jsx
+++ b/src/components/CommunityItem.jsx
@@ -1,0 +1,21 @@
+// src/components/CommunityItem.jsx
+import React from 'react';
+import '../scss/components/_communityItem.scss';
+
+const CommunityItem = ({ group }) => {
+  return (
+    <div className="group-item">
+      <div className="group-icon">
+        <img src={group.image} alt={group.name} />
+      </div>
+      <div className="group-details">
+        <div className="group-name">{group.name}</div>
+        <div className="group-notice">{group.notice}</div>
+        <div className="group-time">{group.time}</div>
+        {group.badge && <div className="group-badge">{group.badge}</div>}
+      </div>
+    </div>
+  );
+};
+
+export default CommunityItem;

--- a/src/components/CreateGroup.jsx
+++ b/src/components/CreateGroup.jsx
@@ -1,0 +1,63 @@
+// src/page/community/CreateGroup.jsx
+import React, { useState } from 'react';
+import '../scss/page/_createGroup.scss';
+
+const CreateGroup = () => {
+  const [groupName, setGroupName] = useState('');
+  const [goalDuration, setGoalDuration] = useState('');
+  const [goalDate, setGoalDate] = useState('');
+  const [members, setMembers] = useState('');
+
+  const handleSubmit = (e) => {
+    e.preventDefault();
+    // 소모임 개설 로직 추가
+    console.log({ groupName, goalDuration, goalDate, members });
+  };
+
+  return (
+    <div className="create-group-page">
+      <h2>소모임 개설</h2>
+      <form onSubmit={handleSubmit}>
+        <div className="form-group">
+          <label>소모임명</label>
+          <input 
+            type="text" 
+            value={groupName} 
+            onChange={(e) => setGroupName(e.target.value)} 
+            placeholder="소모임명을 적어보세요." 
+          />
+        </div>
+        <div className="form-group">
+          <label>목표 기간</label>
+          <input 
+            type="text" 
+            value={goalDuration} 
+            onChange={(e) => setGoalDuration(e.target.value)} 
+            placeholder="목표 기간을 적어보세요." 
+          />
+        </div>
+        <div className="form-group">
+          <label>목표 날짜</label>
+          <input 
+            type="text" 
+            value={goalDate} 
+            onChange={(e) => setGoalDate(e.target.value)} 
+            placeholder="목표 날짜를 적어보세요." 
+          />
+        </div>
+        <div className="form-group">
+          <label>참여 인원</label>
+          <input 
+            type="text" 
+            value={members} 
+            onChange={(e) => setMembers(e.target.value)} 
+            placeholder="참여 인원을 적어보세요." 
+          />
+        </div>
+        <button type="submit">소모임 개설하기</button>
+      </form>
+    </div>
+  );
+};
+
+export default CreateGroup;

--- a/src/page/community/index.jsx
+++ b/src/page/community/index.jsx
@@ -1,24 +1,25 @@
-import React from "react";
-import "../../scss/page/_community.scss"; // 스타일 파일을 정확한 경로로 import
+// src/page/community/index.jsx
+import React, { useState, useEffect } from 'react';
+import CommunityItem from '../../components/CommunityItem';
+import '../../scss/page/_community.scss';
 
 const Community = () => {
-  const groups = [
-    {
-      id: 1,
-      name: "리액트 100일 스터디",
-      notice: "호스트가 공지글을 게시했습니다.",
-      time: "오후 8:36",
-      image: "/path/to/react_study.png",
-    },
-    {
-      id: 2,
-      name: "토익 스터디 커뮤니티",
-      notice: "@Lundean 님이 입장했습니다.",
-      time: "오후 5:40",
-      image: "/path/to/toeic_study.png",
-      badge: "50+",
-    },
-  ];
+  const [groups, setGroups] = useState([]);
+
+  useEffect(() => {
+    const fetchGroups = async () => {
+      try {
+        const response = await fetch('/api/mock/community.json');
+        const data = await response.json();
+        console.log("Fetched data:", data); // 디버깅을 위한 콘솔 로그
+        setGroups(data);
+      } catch (error) {
+        console.error("Failed to fetch community data", error);
+      }
+    };
+
+    fetchGroups();
+  }, []);
 
   return (
     <div className="community-page">
@@ -33,19 +34,13 @@ const Community = () => {
         <button className="create-group">+ 소모임 개설</button>
       </div>
       <div className="group-list">
-        {groups.map((group) => (
-          <div key={group.id} className="group-item">
-            <div className="group-icon">
-              <img src={group.image} alt={group.name} />
-            </div>
-            <div className="group-details">
-              <div className="group-name">{group.name}</div>
-              <div className="group-notice">{group.notice}</div>
-              <div className="group-time">{group.time}</div>
-              {group.badge && <div className="group-badge">{group.badge}</div>}
-            </div>
-          </div>
-        ))}
+        {groups.length > 0 ? (
+          groups.map((group) => (
+            <CommunityItem key={group.id} group={group} />
+          ))
+        ) : (
+          <p>참여중인 커뮤니티를 찾을 수 없음</p>
+        )}
       </div>
     </div>
   );

--- a/src/page/community/index.jsx
+++ b/src/page/community/index.jsx
@@ -1,15 +1,20 @@
 // src/page/community/index.jsx
 import React, { useState, useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
 import CommunityItem from '../../components/CommunityItem';
 import '../../scss/page/_community.scss';
 
 const Community = () => {
   const [groups, setGroups] = useState([]);
+  const navigate = useNavigate();
 
   useEffect(() => {
     const fetchGroups = async () => {
       try {
         const response = await fetch('/api/mock/community.json');
+        if (!response.ok) {
+          throw new Error(`HTTP error! status: ${response.status}`);
+        }
         const data = await response.json();
         console.log("Fetched data:", data); // 디버깅을 위한 콘솔 로그
         setGroups(data);
@@ -21,6 +26,10 @@ const Community = () => {
     fetchGroups();
   }, []);
 
+  const handleCreateGroup = () => {
+    navigate('/create-group');
+  };
+
   return (
     <div className="community-page">
       <div className="community-header">
@@ -31,7 +40,7 @@ const Community = () => {
       </div>
       <div className="community-subheader">
         <span className="subheader-title">참여중인 소모임</span>
-        <button className="create-group">+ 소모임 개설</button>
+        <button className="create-group" onClick={handleCreateGroup}>+ 소모임 개설</button>
       </div>
       <div className="group-list">
         {groups.length > 0 ? (

--- a/src/page/community/index.jsx
+++ b/src/page/community/index.jsx
@@ -1,7 +1,54 @@
-import React from "react"
+import React from "react";
+import "../../scss/page/_community.scss"; // 스타일 파일을 정확한 경로로 import
 
 const Community = () => {
-  return <div>community</div>
-}
+  const groups = [
+    {
+      id: 1,
+      name: "리액트 100일 스터디",
+      notice: "호스트가 공지글을 게시했습니다.",
+      time: "오후 8:36",
+      image: "/path/to/react_study.png",
+    },
+    {
+      id: 2,
+      name: "토익 스터디 커뮤니티",
+      notice: "@Lundean 님이 입장했습니다.",
+      time: "오후 5:40",
+      image: "/path/to/toeic_study.png",
+      badge: "50+",
+    },
+  ];
 
-export default Community
+  return (
+    <div className="community-page">
+      <div className="community-header">
+        <div className="tabs">
+          <button className="tab active">My</button>
+          <button className="tab">커뮤홈</button>
+        </div>
+      </div>
+      <div className="community-subheader">
+        <span className="subheader-title">참여중인 소모임</span>
+        <button className="create-group">+ 소모임 개설</button>
+      </div>
+      <div className="group-list">
+        {groups.map((group) => (
+          <div key={group.id} className="group-item">
+            <div className="group-icon">
+              <img src={group.image} alt={group.name} />
+            </div>
+            <div className="group-details">
+              <div className="group-name">{group.name}</div>
+              <div className="group-notice">{group.notice}</div>
+              <div className="group-time">{group.time}</div>
+              {group.badge && <div className="group-badge">{group.badge}</div>}
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default Community;

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -1,13 +1,13 @@
-import React, { lazy, Suspense } from "react"
-import { createBrowserRouter } from "react-router-dom"
-import Loading from "../components/Loading"
-import Layout from "../layout/Layout"
+import React, { lazy, Suspense } from "react";
+import { createBrowserRouter } from "react-router-dom";
+import Loading from "../components/Loading";
+import Layout from "../layout/Layout";
 
-const Main = lazy(() => import("../page/main"))
-
-const Achievement = lazy(() => import("../page/achievement"))
-const Community = lazy(() => import("../page/community"))
-const Mypage = lazy(() => import("../page/mypage"))
+const Main = lazy(() => import("../page/main"));
+const Achievement = lazy(() => import("../page/achievement"));
+const Community = lazy(() => import("../page/community"));
+const Mypage = lazy(() => import("../page/mypage"));
+const CreateGroup = lazy(() => import("../components/CreateGroup"));
 
 const router = createBrowserRouter([
   {
@@ -45,8 +45,16 @@ const router = createBrowserRouter([
           </Suspense>
         ),
       },
+      {
+        path: "create-group",
+        element: (
+          <Suspense fallback={<Loading />}>
+            <CreateGroup />
+          </Suspense>
+        ),
+      },
     ],
   },
-])
+]);
 
-export default router
+export default router;

--- a/src/scss/components/_communityItem.scss
+++ b/src/scss/components/_communityItem.scss
@@ -1,0 +1,45 @@
+/* src/scss/components/_communityItem.scss */
+.group-item {
+    display: flex;
+    align-items: center;
+    padding: 8px 0;
+    border-bottom: 1px solid #eee;
+    position: relative; /* 추가: 배지를 오른쪽에 고정 */
+  }
+  
+  .group-icon img {
+    width: 40px;
+    height: 40px;
+    border-radius: 20px;
+  }
+  
+  .group-details {
+    flex: 1;
+    margin-left: 16px;
+  }
+  
+  .group-name {
+    font-size: 16px;
+    font-weight: bold;
+  }
+  
+  .group-notice {
+    font-size: 14px;
+    color: #888;
+  }
+  
+  .group-time {
+    font-size: 12px;
+    color: #aaa;
+  }
+  
+  .group-badge {
+    background: #ff4500;
+    color: #fff;
+    border-radius: 12px;
+    padding: 2px 8px;
+    font-size: 12px;
+    position: absolute; /* 추가: 배지 위치 고정 */
+    right: 10px; /* 오른쪽 여백 */
+  }
+  

--- a/src/scss/page/_community.scss
+++ b/src/scss/page/_community.scss
@@ -99,4 +99,3 @@
     font-size: 12px;
     margin-left: auto;
   }
-  

--- a/src/scss/page/_community.scss
+++ b/src/scss/page/_community.scss
@@ -1,0 +1,102 @@
+.community-page {
+    padding: 16px;
+  }
+  
+  .community-header {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    margin-bottom: 30px;
+    position: relative;
+  }
+  
+  .tabs {
+    display: flex;
+    width: 100%;
+    justify-content: space-around;
+  }
+  
+  .tab {
+    padding: 8px 16px;
+    border: none;
+    background: none;
+    cursor: pointer;
+    font-size: 16px;
+    font-weight: bold;
+    color: #aaa;
+    flex-grow: 1;
+    text-align: center;
+  }
+  
+  .tab.active {
+    color: #000;
+    border-bottom: 2px solid #000;
+  }
+  
+  .community-subheader {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 16px;
+  }
+  
+  .subheader-title {
+    font-size: 18px;
+    font-weight: bold;
+  }
+  
+  .create-group {
+    background: none;
+    border: none;
+    color: #007bff;
+    cursor: pointer;
+    font-size: 16px;
+  }
+  
+  .group-list {
+    display: flex;
+    flex-direction: column;
+  }
+  
+  .group-item {
+    display: flex;
+    align-items: center;
+    padding: 8px 0;
+    border-bottom: 1px solid #eee;
+  }
+  
+  .group-icon img {
+    width: 40px;
+    height: 40px;
+    border-radius: 20px;
+  }
+  
+  .group-details {
+    flex: 1;
+    margin-left: 16px;
+  }
+  
+  .group-name {
+    font-size: 16px;
+    font-weight: bold;
+  }
+  
+  .group-notice {
+    font-size: 14px;
+    color: #888;
+  }
+  
+  .group-time {
+    font-size: 12px;
+    color: #aaa;
+  }
+  
+  .group-badge {
+    background: #ff4500;
+    color: #fff;
+    border-radius: 12px;
+    padding: 2px 8px;
+    font-size: 12px;
+    margin-left: auto;
+  }
+  

--- a/src/scss/page/_createGroup.scss
+++ b/src/scss/page/_createGroup.scss
@@ -1,0 +1,38 @@
+// src/scss/page/_createGroup.scss
+.create-group-page {
+    padding: 16px;
+    background: #fff;
+  
+    h2 {
+      margin-bottom: 16px;
+    }
+  
+    .form-group {
+      margin-bottom: 16px;
+  
+      label {
+        display: block;
+        margin-bottom: 8px;
+        font-weight: bold;
+      }
+  
+      input {
+        width: 100%;
+        padding: 8px;
+        border: 1px solid #ccc;
+        border-radius: 4px;
+      }
+    }
+  
+    button {
+      width: 100%;
+      padding: 12px;
+      background-color: #007bff;
+      color: #fff;
+      border: none;
+      border-radius: 4px;
+      cursor: pointer;
+      font-size: 16px;
+    }
+  }
+  

--- a/src/scss/style.scss
+++ b/src/scss/style.scss
@@ -7,3 +7,4 @@
 @import "./components/footer";
 
 @import "./page/main";
+@import "./page/community";

--- a/src/scss/style.scss
+++ b/src/scss/style.scss
@@ -5,6 +5,7 @@
 
 @import "./components/layout";
 @import "./components/footer";
+@import "./components/communityItem";
 
 @import "./page/main";
 @import "./page/community";


### PR DESCRIPTION
------------------------------------------------------------------------------------------------

24/06/29 GDSC FE 프로젝트 했던 내용정리

1.  CommunicationDevelope 브랜치 생성
2. 커뮤니티 페이지 개발


2-1) 커뮤니티 메인 페이지 기능 및 스타일
 
src>page>community>index.jsx = 커뮤니티 메인 페이지 

src>components>CommunityItem.jsx = 커뮤니티 메인 페이지의 참여중인 소모임들 뷰에 표시

src>scss>components>_communityItem.scss = 커뮤니티 메인 페이지에 나타나는 그룹들을 디자인

src>scss>page> _community.scss = 커뮤니티 메인 페이지 디자인




2-2) 커뮤니티 페이지에서 "+소모임 개설" 버튼기능 구현 

src>components>CreateGroup.jsx = "+소모임 개설" 버튼을 눌렀을때 나타나는 화면 뷰 구현

src>scss>page>_createGroup.scss = "+소모임 개설" 버튼을 눌렀을때 나타나는 화면 디자인




2-3) 라우터 처리
src>router>index.js = 앞서 구현했던 "+소모임 개설" 버튼을 눌렀을때 라우터 처리

------------------------------------------------------------------------------------------------

오늘은 일단 이정도 해봤고 하면서 한가지 아쉬웠던점은 src>api>mock>community.json 파일에서 소모임 더미데이터 생성하고 데이터를 뷰에 끌어와서 보여주고 싶었으나 계속 오류가 떠서 일단은 "+소모임 개설" 뷰 먼저 한번 생성해봤음

그 다음 스텝
1.  "+소모임 개설" 버튼을 눌렀을 때 -- 커뮤니티 > My 페이지에 내가 만든 소모임이 뜨도록 하기 
2. 더미데이터 API 호출 성공후 -- 커뮤니티 >My 페이지에 뷰 띄우기
3. 참여중인 소모임 클릭했을시 "소모임 개설하기" 에서 만들었던 정보 띄워주기 (은진 피그마 10번째 디자인 참고)